### PR TITLE
Unwrap exception to get the bottom-most cause

### DIFF
--- a/src/complete/core.clj
+++ b/src/complete/core.clj
@@ -1,4 +1,5 @@
 (ns complete.core
+  (:require [clojure.main])
   (:import [java.util.jar JarFile] [java.io File]))
 
 ;; Code adapted from swank-clojure (http://github.com/jochu/swank-clojure)
@@ -82,7 +83,8 @@
   (try (let [val (resolve sym)]
          (when (class? val) val))
        (catch RuntimeException e
-         (when (not= ClassNotFoundException (class e))
+         (when (not= ClassNotFoundException
+                     (class (clojure.main/repl-exception e)))
            (throw e)))))
 
 (defmulti potential-completions

--- a/test/complete/core_test.clj
+++ b/test/complete/core_test.clj
@@ -2,11 +2,14 @@
   (:use complete.core clojure.test))
 
 (deftest completions-test
-  (is '("alength" "alias" "all-ns" "alter" "alter-meta!" "alter-var-root")
-      (completions "al" 'clojure.core))
+  (is (= '("alength" "alias" "all-ns" "alter" "alter-meta!" "alter-var-root")
+         (completions "al" 'clojure.core)))
 
-  (is '("jio/make-input-stream" "jio/make-output-stream" "jio/make-parents" "jio/make-reader" "jio/make-writer")
-      (completions "jio/make" 'clojure.core))
+  (is (= '("jio/make-input-stream" "jio/make-output-stream" "jio/make-parents" "jio/make-reader" "jio/make-writer")
+         (completions "jio/make" 'clojure.core)))
 
-  (is '("complete.core" "complete.core-test")
-      (completions "complete.core")))
+  (is (= '("clojure.core/alter" "clojure.core/alter-meta!" "clojure.core/alter-var-root")
+         (completions "clojure.core/alt" 'clojure.core)))
+
+  (is (= '("complete.core" "complete.core-test")
+         (completions "complete.core"))))


### PR DESCRIPTION
Looks like I made a bone-headed mistake with the last pull request and omitted the unwrapping that I was doing in REPL-y, so things like clojure.core/<tab> wouldn't work. Sorry about that. I made sure this one comes with a test that fails before the fix is in there.
