### PR TITLE
Allow resolve-class catch to work with 1.2

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,6 @@
-(defproject clojure-complete "0.2.1"
+(defproject clojure-complete "0.2.2-SNAPSHOT"
   :description "Standalone completion library adapted from swank-clojure"
-  :dependencies [[clojure "1.3.0"]])
+  :dependencies [[clojure "1.3.0"]]
+  :multi-deps {
+    "1.2" [[org.clojure/clojure "1.2.0"]]
+    "1.3" [[org.clojure/clojure "1.3.0"]]})

--- a/src/complete/core.clj
+++ b/src/complete/core.clj
@@ -82,7 +82,7 @@
 (defn resolve-class [sym]
   (try (let [val (resolve sym)]
          (when (class? val) val))
-       (catch RuntimeException e
+       (catch Exception e
          (when (not= ClassNotFoundException
                      (class (clojure.main/repl-exception e)))
            (throw e)))))


### PR DESCRIPTION
Add lein-multi to prove it.

I'd like to blame CLJ-855, which causes all this madness, but I should have thought of lein-multi before.
