### PR TITLE
Class names that match */class* get mangled

### DIFF
--- a/src/complete/core.clj
+++ b/src/complete/core.clj
@@ -65,7 +65,7 @@
     file))
 
 (defn- classname [file]
-  (.. file (replace File/separator ".") (replace ".class" "")))
+  (.. file (replace ".class" "") (replace File/separator ".")))
 
 (def top-level-classes
   (future


### PR DESCRIPTION
The classname function within core.clj mangles any class names that match the above pattern.  For example:

(classname "foo/classification/bar.class") => "fooification.bar"

The altered version in this pull request performs this correctly:

(classname "foo/classification/bar.class") => "foo.classification.bar"
