### PR TITLE
Add JDK 9 compatibility and test

### DIFF
--- a/src/complete/core.clj
+++ b/src/complete/core.clj
@@ -62,7 +62,7 @@
           (.replace ^String (.getPath file) path ""))))
 
 (def classfiles
-  (for [prop ["sun.boot.class.path" "java.ext.dirs" "java.class.path"]
+  (for [prop (filter #(System/getProperty %1) ["sun.boot.class.path" "java.ext.dirs" "java.class.path"])
         path (.split (System/getProperty prop) File/pathSeparator)
         ^String file (path-files path) :when (and (.endsWith file ".class") (not (.contains file "__")))]
     file))

--- a/test/complete/core_test.clj
+++ b/test/complete/core_test.clj
@@ -11,6 +11,9 @@
   (is (= '("clojure.core/alter" "clojure.core/alter-meta!" "clojure.core/alter-var-root")
          (completions "clojure.core/alt" 'clojure.core)))
 
+  (is (= '("clojure.core" "clojure.core.ArrayChunk" "clojure.core.ArrayManager" "clojure.core.IVecImpl" "clojure.core.Vec" "clojure.core.VecNode" "clojure.core.VecSeq" "clojure.core.protocols" "clojure.core.protocols.InternalReduce")
+         (completions "clojure.co")))
+
   (is (= '("complete.core" "complete.core-test")
          (completions "complete.core")))
 


### PR DESCRIPTION
* Since `sun.boot.class.path` and `java.ext.dirs` are removed on JDK 9 filter them for nil
* Add a test case

Fixes #24 