### PR TITLE
[ci] Adding .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: clojure
+script: lein test
+
+notifications:
+  email: false
+
+jdk:
+  - oraclejdk8
+  - oraclejdk9


### PR DESCRIPTION
This commit adds a .travis.yml, which @tirkarthi tested on his fork successfully [here](https://travis-ci.org/tirkarthi/clojure-complete/builds/329454061): 