### PR TITLE
Enable tools.deps.alpha access via git

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,6 @@
+{:deps {org.clojure/clojure {:mvn/version "1.3.0"}}
+ :paths ["src"]
+ :aliases {:v1.2 {:override-deps {org.clojure/clojure {:mvn/version "1.2.0"}}}
+           :v1.3 {:override-deps {org.clojure/clojure {:mvn/version "1.3.0"}}}
+           :v1.4 {:override-deps {org.clojure/clojure {:mvn/version "1.4.0"}}}
+           :test {:extra-paths ["test"]}}}


### PR DESCRIPTION
Having a deps.edn provided allows me to pull this artifact from git directly using the new official clj launcher.  This uses the git machinery that tools.deps.alpha exposes. The file helps t.d.a resolve transitive dependencies (this project conveniently has none, other than Clojure itself.)

To launch a REPL, run `clj`.

To launch with access to tests, against an old version of Clojure:

```
clj -R:v1.2 -C:test
```

Once this file is present, other users or libraries will be able to directly pull down this code without needing to release a Maven artifact. Their deps.edn could look like:

```clj
{:deps {org.clojure/clojure {:mvn/version "1.9.0"}
        ninjudd/clojure-complete {:git/url "git@github.com:ninjudd/clojure-complete.git"
                                  :sha "whateverlatestis"}}}
```